### PR TITLE
use github's oidc provider to assume a role

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,10 @@ on:
       - main
       - develop
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   linter:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,13 +59,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: tests
     env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_REGION: ${{ secrets.AWS_REGION }}
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/ecr-oidc-role-for-github
+          aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Log in to Amazon ECR
         run: |


### PR DESCRIPTION
this approach is a significant improvement, eliminating the need for 
manual or complex secret rotation. by configuring gitbub to assume
the `ecr-oidc-role-for-github`, we avoid explicitly setting credentials. 

the aws-actions/configure-aws-credentials@v2 action uses githubs 
OIDC token to assume the role and automatically sets up temporary 
credentials in the environment. these credentials are then used by the 
aws cli to push containers to ECR.