### PR TITLE
oidc auth for cd

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -20,9 +20,9 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/ecr-oidc-role-for-github
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/eks-cluster-management-role
           aws-region: ${{ secrets.AWS_REGION }}
-          
+
       - name: Update kubeconfig
         run: |
           aws eks update-kubeconfig --name ${{ secrets.CLUSTER_NAME }} --region ${{ secrets.AWS_REGION }}

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -17,28 +17,12 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
-      - name: Set up AWS CLI
-        uses: aws-actions/configure-aws-credentials@v1
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/ecr-oidc-role-for-github
           aws-region: ${{ secrets.AWS_REGION }}
-
-      - name: Assume Role
-        id: assume-role
-        run: |
-          ROLE_ARN="arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/eks-cluster-management-role"
-          CREDS_JSON=$(aws sts assume-role --role-arn $ROLE_ARN --role-session-name GitHubActionsSession)
-          echo "::set-output name=aws_access_key_id::$(echo $CREDS_JSON | jq -r .Credentials.AccessKeyId)"
-          echo "::set-output name=aws_secret_access_key::$(echo $CREDS_JSON | jq -r .Credentials.SecretAccessKey)"
-          echo "::set-output name=aws_session_token::$(echo $CREDS_JSON | jq -r .Credentials.SessionToken)"
-
-      - name: Set AWS Credentials from Assumed Role
-        run: |
-          echo "AWS_ACCESS_KEY_ID=${{ steps.assume-role.outputs.aws_access_key_id }}" >> $GITHUB_ENV
-          echo "AWS_SECRET_ACCESS_KEY=${{ steps.assume-role.outputs.aws_secret_access_key }}" >> $GITHUB_ENV
-          echo "AWS_SESSION_TOKEN=${{ steps.assume-role.outputs.aws_session_token }}" >> $GITHUB_ENV
-
+          
       - name: Update kubeconfig
         run: |
           aws eks update-kubeconfig --name ${{ secrets.CLUSTER_NAME }} --region ${{ secrets.AWS_REGION }}


### PR DESCRIPTION
this approach is a significant improvement, eliminating the need for 
manual or complex secret rotation. by configuring gitbub to assume
the `eks-cluster-management-role`, we avoid explicitly setting credentials. 

the aws-actions/configure-aws-credentials@v2 action uses githubs 
OIDC token to assume the role and automatically sets up temporary 
credentials in the environment. these credentials are then used by the 
helm to deploy to EKS.